### PR TITLE
fix: change RouteStep.Exits type from uint16 to string

### DIFF
--- a/types.go
+++ b/types.go
@@ -149,7 +149,7 @@ type (
 		Weight float32 `json:"weight"`
 
 		// Exits is the exit numbers or names of the way. Will be undefined if there are no exit numbers or names.
-		Exits uint16 `json:"exits"`
+		Exits string `json:"exits"`
 
 		// Name of the way along which travel proceeds.
 		Name string `json:"name"`


### PR DESCRIPTION
RouteStep.Exits should be string.

[Example request](http://router.project-osrm.org/trip/v1/car/37.242592,52.682869;37.462397,55.693398;37.485134,55.624254.json?roundtrip=false&source=first&steps=true)

[OSRM-Backend](https://github.com/Project-OSRM/osrm-backend/blob/105448a80ef44ca4c5e7c3ad93b5e83e89b4a9bc/include/engine/guidance/route_step.hpp#L65)